### PR TITLE
Order status added to order history and order page

### DIFF
--- a/src/Components/Order.js
+++ b/src/Components/Order.js
@@ -48,7 +48,8 @@ const _Order = ({ users, auth, match, products, orders })=> {
       </ul>
       <h3>Order Total ${ currentOrder.lineItems.map(lineItem =>
           products.find(product => product.id === lineItem.productId).price * lineItem.quantity)
-            .reduce((acc, curr)=> acc + curr, 0)}
+            .reduce((acc, curr)=> acc + curr, 0)
+            .toFixed(2)}
       </h3>
       <Link to='/profile'>return to profile</Link>
     </div>

--- a/src/Components/Order.js
+++ b/src/Components/Order.js
@@ -22,6 +22,14 @@ const _Order = ({ users, auth, match, products, orders })=> {
     <div className='orderContainer'>
       <h1>Order for {user.name}</h1>
       <h2>Order #{orderId}</h2>
+      {
+        !currentOrder.complete ?
+        <div>
+          <h3>Status: In Progress</h3>
+          <div>Go back to <Link to='/cart'>cart</Link></div>
+        </div> :
+        <h3>Status: Complete</h3>
+      }
       <ul>
         {
           currentOrder.lineItems.map((lineItem, idx) =>

--- a/src/Components/UserProfile.js
+++ b/src/Components/UserProfile.js
@@ -41,7 +41,8 @@ class _UserProfile extends Component {
                 <span> <b>Total:</b> ${ order.lineItems.map(
                   lineItem =>
                     products.find(product => product.id === lineItem.productId).price * lineItem.quantity)
-                      .reduce((acc, curr)=> acc + curr, 0)}
+                      .reduce((acc, curr)=> acc + curr, 0)
+                      .toFixed(2)}
                 </span>
                 {
                   !order.complete ?

--- a/src/Components/UserProfile.js
+++ b/src/Components/UserProfile.js
@@ -37,16 +37,16 @@ class _UserProfile extends Component {
               <div>No Orders</div> :
             user.orders.map( order =>
               <li key={order.id}>
-                Order: <Link to={`/orders/${order.id}`}> #{order.id}</Link>
-                <span> Total: ${ order.lineItems.map(
+                <b>Order:</b> <Link to={`/orders/${order.id}`}> #{order.id}</Link>
+                <span> <b>Total:</b> ${ order.lineItems.map(
                   lineItem =>
                     products.find(product => product.id === lineItem.productId).price * lineItem.quantity)
                       .reduce((acc, curr)=> acc + curr, 0)}
                 </span>
                 {
                   !order.complete ?
-                    <span> Status: incomplete</span> :
-                    <span> Status: complete</span>
+                    <span> <b>Status:</b> In Progess</span> :
+                    <span> <b>Status:</b> Complete</span>
                 }
               </li>
             )

--- a/src/Components/UserProfile.js
+++ b/src/Components/UserProfile.js
@@ -24,7 +24,7 @@ class _UserProfile extends Component {
 
     //find current user
     const user = users.find( user => user.id === auth.id);
-
+    console.log('user in UserProfile', user);
     return (
       <div className='userProfileContainer'>
         <h1>Account Information</h1>
@@ -43,6 +43,11 @@ class _UserProfile extends Component {
                     products.find(product => product.id === lineItem.productId).price * lineItem.quantity)
                       .reduce((acc, curr)=> acc + curr, 0)}
                 </span>
+                {
+                  !order.complete ?
+                    <span> Status: incomplete</span> :
+                    <span> Status: complete</span>
+                }
               </li>
             )
           }


### PR DESCRIPTION
I noticed that the in progress cart for new users (not included in our original seed) gets rendered as an order in the order history after a hard reload (and also only updates on a hard reload), which is interesting because that's not the case for our original 5 users. So I just added a 'Status: In Progress' and a link to car to distinguish the difference to the user.